### PR TITLE
handle package with no classes

### DIFF
--- a/source/index.js
+++ b/source/index.js
@@ -16,7 +16,10 @@ var classesFromPackages = function ( packages )
         {
             pack.classes.forEach( function( c )
             {
-                classes = classes.concat( c.class );
+                if ( c.class )
+                {
+                    classes = classes.concat( c.class );
+                }
             } );
         } );
     } );

--- a/test/assets/sample5.xml
+++ b/test/assets/sample5.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE coverage SYSTEM "http://cobertura.sourceforge.net/xml/coverage-04.dtd">
+<coverage timestamp="1653037542043" line-rate="0.313" lines-covered="102" lines-valid="326" branch-rate="0.0" branches-covered="0" branches-valid="0" complexity="0" version="1.9.4.1">
+    <sources>
+        <source>/removed1/src</source>
+    </sources>
+    <packages>
+        <package name="erlang.package" line-rate="0.313" branch-rate="0.0" complexity="0">
+            <classes>
+                <class name="erlang.class" filename="/removed/src/erlang.erl" line-rate="1.0" branch-rate="0.0" complexity="0">
+                    <methods>
+                        <method name="start" signature="start/2" line-rate="1.0" branch-rate="0.0">
+                            <lines>
+                                <line number="13" hits="16" branch="False"/>
+                            </lines>
+                        </method>
+                        <method name="stop" signature="stop/1" line-rate="1.0" branch-rate="0.0">
+                            <lines>
+                                <line number="16" hits="16" branch="False"/>
+                            </lines>
+                        </method>
+                    </methods>
+                    <lines>
+                        <line number="13" hits="16" branch="False"/>
+                        <line number="16" hits="16" branch="False"/>
+                    </lines>
+                </class>
+            </classes>
+        </package>
+        <package name="empty_package" line-rate="0.0" branch-rate="0.0" complexity="0">
+            <classes/>
+        </package>
+    </packages>
+</coverage>

--- a/test/index.js
+++ b/test/index.js
@@ -103,4 +103,22 @@ describe( "parseFile", function ()
             done();
         } );
     } );
+
+    it( "should parse a file without empty classes", function ( done )
+    {
+        parse.parseFile( path.join( __dirname, "assets", "sample5.xml" ), function ( err, result )
+        {
+            console.log('result -->', err, JSON.stringify(result[0]));
+            assert.equal( err, null );
+            assert.equal( result.length, 1);
+            assert.equal( result[ 0 ].functions.found, 2 );
+            assert.equal( result[ 0 ].functions.hit, 2 );
+            assert.equal( result[ 0 ].lines.found, 2 );
+            assert.equal( result[ 0 ].lines.hit, 2 );
+            assert.equal( result[ 0 ].functions.details.length, 2 );
+            assert.equal( result[ 0 ].lines.details.length, 2 );
+            done();
+        } );
+    } );
+
 } );


### PR DESCRIPTION
This patch resolves the issue seen here https://github.com/ryanluker/vscode-coverage-gutters/issues/354

Caused by
```
        <package name="empty_package" line-rate="0.0" branch-rate="0.0" complexity="0">
            <classes/>
        </package>
```