### PR TITLE
Fix regex match to not expload list when not nice decimal values

### DIFF
--- a/source/index.js
+++ b/source/index.js
@@ -36,7 +36,7 @@ var extractLcovStyleBranches = function ( c ) {
         {
             if ( l.$.branch == 'true' )
             {
-                var branchStats = l.$['condition-coverage'].match( /\d+/g );
+                var branchStats = l.$['condition-coverage'].match( /[\d|\.]+/g );
                 var coveredBranches = Number( branchStats[1] );
                 var totalBranches = Number( branchStats[2] );
                 var leftBranches = totalBranches - coveredBranches;

--- a/test/assets/sample.xml
+++ b/test/assets/sample.xml
@@ -138,6 +138,7 @@ version="0.1">
                         <line number="110" hits="1" branch="false" />
                         <line number="114" hits="6" branch="false" />
                         <line number="116" hits="0" branch="false" />
+                        <line number="117" hits="6" branch="true" condition-coverage="85.7142857143% (6/7)" />
                     </lines>
                 </class>
                 <class name="bundling.js" filename="controllers\app\bundling.js" line-rate="0.9333"

--- a/test/index.js
+++ b/test/index.js
@@ -15,8 +15,8 @@ describe( "parseFile", function ()
             assert.equal( result.length, 4 );
             assert.equal( result[ 0 ].functions.found, 16 );
             assert.equal( result[ 0 ].functions.hit, 14 );
-            assert.equal( result[ 0 ].lines.found, 45 );
-            assert.equal( result[ 0 ].lines.hit, 40 );
+            assert.equal( result[ 0 ].lines.found, 46 );
+            assert.equal( result[ 0 ].lines.hit, 41 );
             assert.equal( result[ 0 ].functions.details[ 0 ].line, 5 );
             assert.equal( result[ 0 ].functions.details[ 0 ].hit, 6 );
             assert.equal( result[ 0 ].lines.details[ 0 ].line, 2 );
@@ -46,8 +46,8 @@ describe( "parseFile", function ()
         parse.parseFile( path.join( __dirname, "assets", "sample.xml" ), function ( err, result )
         {
             assert.equal( err, null );
-            assert.equal( result[ 0 ].branches.found, 6 );
-            assert.equal( result[ 0 ].branches.hit, 3 );
+            assert.equal( result[ 0 ].branches.found, 13 );
+            assert.equal( result[ 0 ].branches.hit, 9 );
             assert.equal( result[ 0 ].branches.details[ 0 ].taken, 0 );
             assert.equal( result[ 0 ].branches.details[ 1 ].taken, 1 );
             assert.equal( result[ 0 ].branches.details[ 2 ].taken, 0 );


### PR DESCRIPTION
This patch fixes the error seen here https://github.com/ryanluker/vscode-coverage-gutters/issues/312

This is caused by the regex not including the '.' from the branch coverage % for non 'nice' ratios i.e 6/7 
with a branch hit rate of 6/7 the reported coverage line is 
`
<line number="117" hits="6" branch="true" condition-coverage="85.7142857143% (6/7)" />
`

The existing regex will read the `coveredBranches` as `7142857143` and try and add 7 Billion branches to the branches list causing node to run out of memory.

The fix allows for the literal '.' char to be in the match groups